### PR TITLE
Pdu max length

### DIFF
--- a/src/odil/Association.cpp
+++ b/src/odil/Association.cpp
@@ -463,8 +463,8 @@ Association
         command_stream, registry::ImplicitVRLittleEndian, // implicit vr for command
         Writer::ItemEncoding::ExplicitLength, true); // true for Command
     command_writer.write_data_set(message.get_command_set());
-    pdv_items.push_back(
-        pdu::PDataTF::PresentationDataValueItem(id, 3, command_stream.str()));
+    auto const command_buffer = command_stream.str();
+    pdv_items.emplace_back(id, 3, command_buffer);
 
     if (message.has_data_set())
     {
@@ -473,17 +473,55 @@ Association
             data_stream, transfer_syntax,
             Writer::ItemEncoding::ExplicitLength, false);
         data_writer.write_data_set(message.get_data_set());
-        pdv_items.push_back(
-            pdu::PDataTF::PresentationDataValueItem(
-                transfer_syntax_it->second.first, 2, data_stream.str()));
+        auto const data_buffer = data_stream.str();
+
+        auto const max_length = this->_association_parameters.get_maximum_length();
+        auto current_length = command_buffer.size() + 12; // 12 is the size of all that is added on top of the fragment
+        if (!max_length 
+            || (current_length + data_buffer.size() + 6 < max_length))
+        {   // Can send all the buffer in one go
+            pdv_items.emplace_back(transfer_syntax_it->second.first, 2, data_buffer);
+
+            dul::EventData data;
+            data.pdu = std::make_shared<pdu::PDataTF>(pdv_items);
+            this->_state_machine.send_pdu(data);
+        }
+        else // We have to fragment into multiple PDUs
+        {
+            auto available = max_length - 6 - current_length; // Need at least 6 bytes for the headers
+            int64_t remaining = data_buffer.size();
+            std::size_t offset = 0;
+
+            if (available > 0) // Send some data with the command set
+            {
+                remaining -= available;
+                pdv_items.emplace_back(transfer_syntax_it->second.first, (remaining > 0 ? 0 : 2), data_buffer.substr(0, available));
+                offset += available;
+            }
+
+            auto pdu = std::make_shared<pdu::PDataTF>(pdv_items);
+            dul::EventData data;
+            data.pdu = pdu;
+            this->_state_machine.send_pdu(data);
+
+            available = max_length - 6; // In case some software do not take into account the size of the header when allocating their buffer
+            while (remaining > 0)
+            {
+                remaining -= available;
+                pdv_items.clear();
+                pdv_items.emplace_back(transfer_syntax_it->second.first, (remaining > 0 ? 0 : 2), data_buffer.substr(offset, available));
+                offset += available;
+                pdu->set_pdv_items(pdv_items);
+                this->_state_machine.send_pdu(data);
+            }
+        }
     }
-
-    auto pdu = std::make_shared<pdu::PDataTF>(pdv_items);
-
-    dul::EventData data;
-    data.pdu = pdu;
-
-    this->_state_machine.send_pdu(data);
+    else
+    {
+        dul::EventData data;
+        data.pdu = std::make_shared<pdu::PDataTF>(pdv_items);
+        this->_state_machine.send_pdu(data);
+    }
 }
 
 uint16_t

--- a/src/odil/StoreSCU.h
+++ b/src/odil/StoreSCU.h
@@ -28,6 +28,8 @@ public:
     
     /// @brief Set the affected SOP class based on the dataset.
     void set_affected_sop_class(DataSet const & dataset);
+
+	using SCU::set_affected_sop_class;
     
     /// @brief Perform the C-STORE.
     void store(DataSet const & dataset) const;

--- a/src/odil/logging.cpp
+++ b/src/odil/logging.cpp
@@ -26,6 +26,8 @@ bool configure()
     auto & root = log4cpp::Category::getRoot();
     root.setPriority(log4cpp::Priority::WARN);
     root.addAppender(appender);
+
+    return true;
 }
 
 static bool const configured = configure();


### PR DESCRIPTION
I propose to automatically fragment a message into PDUs of appropriate size if a maximum PDU length was agreed upon during negotiation.

Also fix a missing return statement in logging.cpp and made visible a base method in StoreSCU.