### PR TITLE
Fixed bugs in Association

### DIFF
--- a/src/odil/Association.cpp
+++ b/src/odil/Association.cpp
@@ -475,7 +475,7 @@ Association
         data_writer.write_data_set(message.get_data_set());
         auto const data_buffer = data_stream.str();
 
-        auto const max_length = this->_association_parameters.get_maximum_length();
+        auto const max_length = this->_negotiated_parameters.get_maximum_length();
         auto current_length = command_buffer.size() + 12; // 12 is the size of all that is added on top of the fragment
         if (!max_length 
             || (current_length + data_buffer.size() + 6 < max_length))

--- a/src/odil/AssociationAcceptor.cpp
+++ b/src/odil/AssociationAcceptor.cpp
@@ -23,8 +23,8 @@ default_association_acceptor(AssociationParameters const & input)
 {
     AssociationParameters output;
 
-    output.set_called_ae_title(input.get_calling_ae_title());
-    output.set_calling_ae_title(input.get_called_ae_title());
+    output.set_called_ae_title(input.get_called_ae_title());
+    output.set_calling_ae_title(input.get_calling_ae_title());
 
     std::vector<AssociationParameters::PresentationContext>
         presentation_contexts = input.get_presentation_contexts();


### PR DESCRIPTION
The PDU max length used in send_message was wrong when odil has initiated the association.
The example of association acceptor is wrong as the given AETs must be written back unchanged (not swapped).