### PR TITLE
Remove exceptions from VRFinder

### DIFF
--- a/src/odil/VRFinder.cpp
+++ b/src/odil/VRFinder.cpp
@@ -46,7 +46,10 @@ VRFinder::operator()(
         try
         {
             vr = finder(tag, data_set, transfer_syntax);
-            break;
+            if (vr != VR::UNKNOWN)
+            {
+                break;
+            }
         }
         catch(Exception &)
         {
@@ -61,7 +64,10 @@ VRFinder::operator()(
             try
             {
                 vr = finder(tag, data_set, transfer_syntax);
-                break;
+                if (vr != VR::UNKNOWN)
+                {
+                    break;
+                }
             }
             catch(Exception &)
             {
@@ -83,18 +89,12 @@ VRFinder
 ::public_dictionary(
     Tag const & tag, DataSet const &, std::string const &)
 {
-    VR vr = VR::INVALID;
+    VR vr = VR::UNKNOWN;
     
     auto const iterator = find(registry::public_dictionary, tag);
     if(iterator != registry::public_dictionary.end())
     {
         vr = as_vr(iterator->second.vr);
-    }
-
-    if(vr == VR::INVALID)
-    {
-        throw Exception(
-            "Element " + std::string(tag) + " is not in the public dictionary");
     }
 
     return vr;
@@ -109,10 +109,8 @@ VRFinder
     {
         return VR::UL;
     }
-    else
-    {
-        throw Exception("Not a group length tag");
-    }
+  
+    return VR::UNKNOWN; // Not a group length tag
 }
 
 VR
@@ -124,10 +122,8 @@ VRFinder
     {
         return VR::UN;
     }
-    else
-    {
-        throw Exception("Not a private tag");
-    }
+
+    return VR::UNKNOWN; // Not a private tag
 }
 
 VR
@@ -194,12 +190,14 @@ VRFinder
         }
         else
         {
-            throw Exception("Unknown tag");
+            // Unknown tag
+            return VR::UNKNOWN;
         }
     }
     else
     {
-        throw Exception("Unknown transfer syntax");
+        // Unknown transfer syntax
+        return VR::UNKNOWN;
     }
 }
 
@@ -273,12 +271,14 @@ VRFinder
         }
         else
         {
-            throw Exception("Unknown tag");
+            // Unknown tag
+            return VR::UNKNOWN;
         }
     }
     else
     {
-        throw Exception("Unknown transfer syntax");
+        // Unknown transfer syntax
+        return VR::UNKNOWN;
     }
 }
 

--- a/tests/code/VRFinder.cpp
+++ b/tests/code/VRFinder.cpp
@@ -50,11 +50,10 @@ BOOST_AUTO_TEST_CASE(PublicDictionaryRepeatingGroup)
 
 BOOST_AUTO_TEST_CASE(PublicDictionaryNotApplicable)
 {
-    BOOST_REQUIRE_THROW(
-        odil::VRFinder::public_dictionary(
+    auto const vr = odil::VRFinder::public_dictionary(
             odil::Tag(0x0011, 0x0011), odil::DataSet(),
-            odil::registry::ImplicitVRLittleEndian),
-        odil::Exception);
+            odil::registry::ImplicitVRLittleEndian);
+    BOOST_REQUIRE(vr == odil::VR::UNKNOWN);
 }
 
 BOOST_AUTO_TEST_CASE(GroupLength)
@@ -67,11 +66,10 @@ BOOST_AUTO_TEST_CASE(GroupLength)
 
 BOOST_AUTO_TEST_CASE(GroupLengthNotApplicable)
 {
-    BOOST_REQUIRE_THROW(
-        odil::VRFinder::group_length(
+    auto const vr = odil::VRFinder::group_length(
             odil::Tag(0x0010, 0x0010), odil::DataSet(),
-            odil::registry::ImplicitVRLittleEndian),
-        odil::Exception);
+            odil::registry::ImplicitVRLittleEndian);
+    BOOST_REQUIRE(vr == odil::VR::UNKNOWN);
 }
 
 BOOST_AUTO_TEST_CASE(PrivateTag)
@@ -84,11 +82,10 @@ BOOST_AUTO_TEST_CASE(PrivateTag)
 
 BOOST_AUTO_TEST_CASE(PrivateTagNotApplicable)
 {
-    BOOST_REQUIRE_THROW(
-        odil::VRFinder::private_tag(
+    auto const vr = odil::VRFinder::private_tag(
             odil::Tag(0x0010, 0x0010), odil::DataSet(),
-            odil::registry::ImplicitVRLittleEndian),
-        odil::Exception);
+            odil::registry::ImplicitVRLittleEndian);
+    BOOST_REQUIRE(vr == odil::VR::UNKNOWN);
 }
 
 BOOST_AUTO_TEST_CASE(ImplictiVRLittleEndian)
@@ -101,20 +98,18 @@ BOOST_AUTO_TEST_CASE(ImplictiVRLittleEndian)
 
 BOOST_AUTO_TEST_CASE(ImplictiVRLittleEndianNotApplicableTag)
 {
-    BOOST_REQUIRE_THROW(
-        odil::VRFinder::implicit_vr_little_endian(
+    auto const vr = odil::VRFinder::implicit_vr_little_endian(
             odil::Tag(0x0010, 0x0010), odil::DataSet(),
-            odil::registry::ImplicitVRLittleEndian),
-        odil::Exception);
+            odil::registry::ImplicitVRLittleEndian);
+    BOOST_REQUIRE(vr == odil::VR::UNKNOWN);
 }
 
 BOOST_AUTO_TEST_CASE(ImplictiVRLittleEndianNotApplicableVR)
 {
-    BOOST_REQUIRE_THROW(
-        odil::VRFinder::implicit_vr_little_endian(
+    auto const vr = odil::VRFinder::implicit_vr_little_endian(
             odil::Tag(0x7fe0, 0x0010), odil::DataSet(),
-            odil::registry::ExplicitVRLittleEndian),
-        odil::Exception);
+            odil::registry::ExplicitVRLittleEndian);
+    BOOST_REQUIRE(vr == odil::VR::UNKNOWN);
 }
 
 BOOST_AUTO_TEST_CASE(PublicElement)


### PR DESCRIPTION
When looking up for a VR, the class VRFinder launched exceptions at each step of the algorithm.
I am of the opinion that we must only throw an exception to signal that a function can't perform its assigned task. 
This also makes it harder to debug odil when stopping on exceptions as we catch dozen of them for each command set.

I propose to return instead VR::UNKOWN when the finder does not know the type.