### PR TITLE
Add setters for the move originator information.

### DIFF
--- a/src/odil/MoveSCP.cpp
+++ b/src/odil/MoveSCP.cpp
@@ -75,6 +75,9 @@ MoveSCP
     unsigned int failed_sub_operations=0;
     unsigned int warning_sub_operations=0;
 
+    auto const& move_originator_aet = this->_association.get_negotiated_parameters().get_calling_ae_title();
+    auto move_originator_message_id = request.get_message_id();
+
     try
     {
         this->_generator->initialize(request);
@@ -99,7 +102,7 @@ MoveSCP
             store_scu.set_affected_sop_class(data_set);
             try
             {
-                store_scu.store(data_set);
+                store_scu.store(data_set, move_originator_aet, move_originator_message_id);
 
                 --remaining_sub_operations;
                 ++completed_sub_operations;

--- a/src/odil/StoreSCU.cpp
+++ b/src/odil/StoreSCU.cpp
@@ -64,14 +64,19 @@ StoreSCU
 
 void 
 StoreSCU
-::store(DataSet const & dataset) const
+::store(
+    DataSet const & dataset,
+    Value::String const & move_originator_ae_title,
+    Value::Integer move_originator_message_id) const
 {
     message::CStoreRequest const request(
         this->_association.next_message_id(),
         this->_affected_sop_class,
         dataset.as_string(registry::SOPInstanceUID, 0),
         message::Message::Priority::MEDIUM,
-        dataset);
+        dataset, move_originator_ae_title,
+        move_originator_message_id);
+
     this->_association.send_message(request, this->_affected_sop_class);
     
     message::CStoreResponse const response = this->_association.receive_message();

--- a/src/odil/StoreSCU.h
+++ b/src/odil/StoreSCU.h
@@ -32,7 +32,10 @@ public:
 	using SCU::set_affected_sop_class;
     
     /// @brief Perform the C-STORE.
-    void store(DataSet const & dataset) const;
+    void store(
+        DataSet const & dataset,
+        Value::String const & move_originator_ae_title = "",
+        Value::Integer move_originator_message_id = -1) const;
 };
 
 }

--- a/src/odil/message/CStoreRequest.cpp
+++ b/src/odil/message/CStoreRequest.cpp
@@ -23,13 +23,20 @@ CStoreRequest
 ::CStoreRequest(
     Value::Integer message_id, Value::String const & affected_sop_class_uid,
     Value::String const & affected_sop_instance_uid,
-    Value::Integer priority, DataSet const & dataset)
+    Value::Integer priority, DataSet const & dataset,
+    Value::String const & move_originator_ae_title,
+    Value::Integer move_originator_message_id)
 : Request(message_id)
 {
     this->set_command_field(Command::C_STORE_RQ);
     this->set_affected_sop_class_uid(affected_sop_class_uid);
     this->set_affected_sop_instance_uid(affected_sop_instance_uid);
     this->set_priority(priority);
+
+    if(!move_originator_ae_title.empty())
+        this->set_move_originator_ae_title(move_originator_ae_title);
+    if(move_originator_message_id >= 0)
+        this->set_move_originator_message_id(move_originator_message_id);
 
     if(dataset.empty())
     {

--- a/src/odil/message/CStoreRequest.h
+++ b/src/odil/message/CStoreRequest.h
@@ -33,7 +33,9 @@ public:
     CStoreRequest(
         Value::Integer message_id, Value::String const & affected_sop_class_uid,
         Value::String const & affected_sop_instance_uid,
-        Value::Integer priority, DataSet const & dataset);
+        Value::Integer priority, DataSet const & dataset,
+        Value::String const & move_originator_ae_title = "",
+        Value::Integer move_originator_message_id = -1);
 
     /**
      * @brief Create a C-STORE-RQ from a generic Message.

--- a/wrappers/StoreSCU.cpp
+++ b/wrappers/StoreSCU.cpp
@@ -10,7 +10,7 @@
 
 #include "odil/StoreSCU.h"
 
-BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(storeMethod, StoreSCU::store, 1, 3)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(storeMethod, odil::StoreSCU::store, 1, 3)
 
 void wrap_StoreSCU()
 {

--- a/wrappers/StoreSCU.cpp
+++ b/wrappers/StoreSCU.cpp
@@ -10,6 +10,8 @@
 
 #include "odil/StoreSCU.h"
 
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(storeMethod, StoreSCU::store, 1, 3)
+
 void wrap_StoreSCU()
 {
     using namespace boost::python;
@@ -27,7 +29,8 @@ void wrap_StoreSCU()
         )
         .def(
             "store", 
-            &StoreSCU::store
+            &StoreSCU::store,
+            storeMethod()
         )
     ;
 }


### PR DESCRIPTION
It was not possible in StoreSCU to directly set the move originator message id and AET.