### PR TITLE
Add setters for the implementation class uid and version name.

### DIFF
--- a/src/odil/uid.cpp
+++ b/src/odil/uid.cpp
@@ -26,6 +26,17 @@ std::string const implementation_version_name="Odil " ODIL_STRINGIFY(ODIL_MAJOR_
 #error ODIL_MAJOR_VERSION must be defined
 #endif
 
+void set_implementation_class_uid(std::string const & implementation_class_uid)
+{
+    const_cast<std::string&>(odil::implementation_class_uid) = implementation_class_uid;
+}
+
+
+void set_implementation_version_name(std::string const & implementation_version_name)
+{
+    const_cast<std::string&>(odil::implementation_version_name) = implementation_version_name;
+}
+
 std::string generate_uid()
 {
     static std::random_device generator;

--- a/src/odil/uid.h
+++ b/src/odil/uid.h
@@ -23,6 +23,12 @@ extern std::string const implementation_class_uid;
 /// @brief Implementation version name of Odil.
 extern std::string const implementation_version_name;
 
+/// @brief Set the implementation class UID
+void set_implementation_class_uid(std::string const & implementation_class_uid);
+
+/// @brief Set the implementation version name
+void set_implementation_version_name(std::string const & implementation_version_name);
+
 /// @brief Generate a UID under the UID prefix.
 std::string generate_uid();
 

--- a/src/odil/uid.h
+++ b/src/odil/uid.h
@@ -9,6 +9,7 @@
 #ifndef _d8ae0008_075b_4a28_a241_1c6fb1a6c79b
 #define _d8ae0008_075b_4a28_a241_1c6fb1a6c79b
 
+#include "odil/odil.h"
 #include <string>
 
 namespace odil
@@ -18,10 +19,10 @@ namespace odil
 std::string const uid_prefix="1.2.826.0.1.3680043.9.5560";
 
 /// @brief Implementation class UID of Odil.
-extern std::string const implementation_class_uid;
+extern ODIL_API std::string const implementation_class_uid;
 
 /// @brief Implementation version name of Odil.
-extern std::string const implementation_version_name;
+extern ODIL_API std::string const implementation_version_name;
 
 /// @brief Set the implementation class UID
 void set_implementation_class_uid(std::string const & implementation_class_uid);


### PR DESCRIPTION
I need to be able to set my product name (replacing the default odil values).

The fastest way to make it work, and with the least amount of changes, is to use a const_cast which I am not fond of...