### PR TITLE
Add original transfer syntax to DataSet.

### DIFF
--- a/src/odil/DataSet.cpp
+++ b/src/odil/DataSet.cpp
@@ -22,7 +22,8 @@ namespace odil
 {
 
 DataSet
-::DataSet()
+::DataSet(const std::string transfer_syntax)
+: _transfer_syntax(transfer_syntax)
 {
     // Nothing to do.
 }
@@ -449,6 +450,13 @@ DataSet
 ::operator!=(DataSet const & other) const
 {
     return !(*this == other);
+}
+
+std::string const & 
+DataSet
+::get_transfer_syntax() const
+{
+    return _transfer_syntax;
 }
 
 }

--- a/src/odil/DataSet.h
+++ b/src/odil/DataSet.h
@@ -29,7 +29,7 @@ class DataSet
 {
 public:
     /// @brief Create an empty data set.
-    DataSet();
+    explicit DataSet(const std::string transfer_syntax = "");
 
     /// @brief Add an element to the dataset.
     void add(Tag const & tag, Element const & element);
@@ -209,10 +209,16 @@ public:
     /// @brief Difference test.
     bool operator!=(DataSet const & other) const;
 
+    /// @brief Return the transfer syntax in which this DataSet was originally read.
+    std::string const & get_transfer_syntax() const;
+
 private:
     typedef std::map<Tag, Element> ElementMap;
 
     ElementMap _elements;
+
+    /// @brief Transfer syntax initially used to create the DataSet.
+    std::string _transfer_syntax;
 };
 
 }

--- a/src/odil/Reader.cpp
+++ b/src/odil/Reader.cpp
@@ -93,7 +93,7 @@ DataSet
 Reader
 ::read_data_set(std::function<bool(Tag const &)> halt_condition) const
 {
-    DataSet data_set;
+    DataSet data_set(transfer_syntax);
 
     bool done = (this->stream.peek() == EOF);
     while(!done)


### PR DESCRIPTION
There could be more uses than just the Reader, but this is a first step.