### PR TITLE
Members initialization in AssociationParameters

### DIFF
--- a/src/odil/AssociationParameters.cpp
+++ b/src/odil/AssociationParameters.cpp
@@ -104,18 +104,12 @@ AssociationParameters::UserIdentity
 
 AssociationParameters
 ::AssociationParameters()
-: _called_ae_title(""), _calling_ae_title(""), _presentation_contexts(),
-  _user_identity({UserIdentity::Type::None, "", ""}), _maximum_length(16384),
-  _maximum_number_operations_invoked(1), _maximum_number_operations_performed(1),
-  _sop_class_extended_negotiation(), _sop_class_common_extended_negotiation()
 {
     // Nothing else.
 }
 
 AssociationParameters
 ::AssociationParameters(pdu::AAssociateRQ const & pdu)
-: _called_ae_title(""), _calling_ae_title(""), _presentation_contexts(),
-  _user_identity(), _maximum_length(16384)
 {
     this->set_called_ae_title(pdu.get_called_ae_title());
     this->set_calling_ae_title(pdu.get_calling_ae_title());

--- a/src/odil/AssociationParameters.h
+++ b/src/odil/AssociationParameters.h
@@ -227,9 +227,9 @@ private:
     std::string _calling_ae_title;
     std::vector<PresentationContext> _presentation_contexts;
     UserIdentity _user_identity;
-    uint32_t _maximum_length;
-    uint16_t _maximum_number_operations_invoked;
-    uint16_t _maximum_number_operations_performed;
+    uint32_t _maximum_length = 16384;
+    uint16_t _maximum_number_operations_invoked = 1;
+    uint16_t _maximum_number_operations_performed = 1;
     std::vector<pdu::SOPClassExtendedNegotiation>
         _sop_class_extended_negotiation;
     std::vector<pdu::SOPClassCommonExtendedNegotiation> 


### PR DESCRIPTION
There are currently 3 constructors for AssociationParameters, but not all initialize all the class members.
We can factor using class member initializers.
Also, calling default constructors for members is not necessary. 