### PR TITLE
Fix compilation of tests with VS2015.

### DIFF
--- a/tests/code/DataSet.cpp
+++ b/tests/code/DataSet.cpp
@@ -263,7 +263,7 @@ void test_element(
 
 BOOST_AUTO_TEST_CASE(Int)
 {
-    test_element(
+    test_element<odil::Value::Integers>(
         odil::registry::Rows, {1234, 5678}, odil::VR::US,
         &odil::DataSet::is_int, 
         &odil::DataSet::as_int, &odil::DataSet::as_int, &odil::DataSet::as_int);
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE(Int)
 
 BOOST_AUTO_TEST_CASE(Real)
 {
-    test_element(
+    test_element<odil::Value::Reals>(
         odil::registry::SpacingBetweenSlices, {12.34, 56.78}, odil::VR::FL,
         &odil::DataSet::is_real, 
         &odil::DataSet::as_real, &odil::DataSet::as_real, &odil::DataSet::as_real);
@@ -279,7 +279,7 @@ BOOST_AUTO_TEST_CASE(Real)
 
 BOOST_AUTO_TEST_CASE(String)
 {
-    test_element(
+    test_element<odil::Value::Strings>(
         odil::registry::PatientID, {"foo", "bar"}, odil::VR::LT,
         &odil::DataSet::is_string, 
         &odil::DataSet::as_string, &odil::DataSet::as_string, &odil::DataSet::as_string);
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE(DataSets)
     odil::DataSet data_set_2;
     data_set_2.add("EchoTime", {100});
 
-    test_element(
+    test_element<odil::Value::DataSets>(
         odil::registry::ReferencedStudySequence, {data_set_1, data_set_2}, odil::VR::SQ,
         &odil::DataSet::is_data_set, 
         &odil::DataSet::as_data_set, &odil::DataSet::as_data_set, &odil::DataSet::as_data_set);
@@ -301,7 +301,7 @@ BOOST_AUTO_TEST_CASE(DataSets)
 
 BOOST_AUTO_TEST_CASE(Binary)
 {
-    test_element(
+    test_element<odil::Value::Binary>(
         odil::registry::BadPixelImage, {{0x1, 0x2}, {0x3}}, odil::VR::OB,
         &odil::DataSet::is_binary,
         &odil::DataSet::as_binary, &odil::DataSet::as_binary, &odil::DataSet::as_binary);

--- a/tests/code/Element.cpp
+++ b/tests/code/Element.cpp
@@ -173,73 +173,73 @@ void test(
 
 BOOST_AUTO_TEST_CASE(ImplicitType)
 {
-    test_implicit_container(
+    test_implicit_container<odil::Value::Strings>(
         odil::VR::AE, &odil::Element::is_string, &odil::Element::as_string);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Strings>(
         odil::VR::AS, &odil::Element::is_string, &odil::Element::as_string);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Strings>(
         odil::VR::AT, &odil::Element::is_string, &odil::Element::as_string);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Strings>(
         odil::VR::CS, &odil::Element::is_string, &odil::Element::as_string);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Strings>(
         odil::VR::DA, &odil::Element::is_string, &odil::Element::as_string);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Reals>(
         odil::VR::DS, &odil::Element::is_real, &odil::Element::as_real);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Strings>(
         odil::VR::DT, &odil::Element::is_string, &odil::Element::as_string);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Reals>(
         odil::VR::FL, &odil::Element::is_real, &odil::Element::as_real);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Reals>(
         odil::VR::FD, &odil::Element::is_real, &odil::Element::as_real);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Integers>(
         odil::VR::IS, &odil::Element::is_int, &odil::Element::as_int);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Strings>(
         odil::VR::LO, &odil::Element::is_string, &odil::Element::as_string);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Strings>(
         odil::VR::LT, &odil::Element::is_string, &odil::Element::as_string);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Binary>(
         odil::VR::OB, &odil::Element::is_binary, &odil::Element::as_binary);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Binary>(
         odil::VR::OD, &odil::Element::is_binary, &odil::Element::as_binary);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Binary>(
         odil::VR::OF, &odil::Element::is_binary, &odil::Element::as_binary);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Binary>(
         odil::VR::OL, &odil::Element::is_binary, &odil::Element::as_binary);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Binary>(
         odil::VR::OW, &odil::Element::is_binary, &odil::Element::as_binary);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Strings>(
         odil::VR::PN, &odil::Element::is_string, &odil::Element::as_string);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Strings>(
         odil::VR::SH, &odil::Element::is_string, &odil::Element::as_string);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Integers>(
         odil::VR::SL, &odil::Element::is_int, &odil::Element::as_int);
-    test_implicit_container(
+    test_implicit_container<odil::Value::DataSets>(
         odil::VR::SQ, &odil::Element::is_data_set, &odil::Element::as_data_set);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Integers>(
         odil::VR::SS, &odil::Element::is_int, &odil::Element::as_int);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Strings>(
         odil::VR::ST, &odil::Element::is_string, &odil::Element::as_string);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Strings>(
         odil::VR::TM, &odil::Element::is_string, &odil::Element::as_string);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Strings>(
         odil::VR::UC, &odil::Element::is_string, &odil::Element::as_string);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Strings>(
         odil::VR::UI, &odil::Element::is_string, &odil::Element::as_string);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Integers>(
         odil::VR::UL, &odil::Element::is_int, &odil::Element::as_int);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Binary>(
         odil::VR::UN, &odil::Element::is_binary, &odil::Element::as_binary);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Strings>(
         odil::VR::UR, &odil::Element::is_string, &odil::Element::as_string);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Integers>(
         odil::VR::US, &odil::Element::is_int, &odil::Element::as_int);
-    test_implicit_container(
+    test_implicit_container<odil::Value::Strings>(
         odil::VR::UT, &odil::Element::is_string, &odil::Element::as_string);
 }
 
 BOOST_AUTO_TEST_CASE(Int)
 {
-    test(
+    test<odil::Value::Integers>(
         {1234, 5678}, {9012, 3456}, odil::VR::US, odil::VR::UL, 
         &odil::Element::is_int,
         &odil::Element::as_int, &odil::Element::as_int);
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE(Int)
 
 BOOST_AUTO_TEST_CASE(Real)
 {
-    test(
+    test<odil::Value::Reals>(
         {12.34, 56.78}, {1., 2.}, odil::VR::FD, odil::VR::DS, 
         &odil::Element::is_real,
         &odil::Element::as_real, &odil::Element::as_real);
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(Real)
 
 BOOST_AUTO_TEST_CASE(String)
 {
-    test(
+    test<odil::Value::Strings>(
         {"foo", "bar"}, {"plip", "plop"}, odil::VR::CS, odil::VR::UT, 
         &odil::Element::is_string,
         &odil::Element::as_string, &odil::Element::as_string);
@@ -269,7 +269,7 @@ BOOST_AUTO_TEST_CASE(DataSets)
     odil::DataSet data_set_2;
     data_set_2.add("EchoTime", {100});
 
-    test(
+    test<odil::Value::DataSets>(
         {data_set_1, data_set_2}, {data_set_2, data_set_1}, 
         odil::VR::SQ, odil::VR::UN,
         &odil::Element::is_data_set,
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE(DataSets)
 
 BOOST_AUTO_TEST_CASE(Binary)
 {
-    test(
+    test<odil::Value::Binary>(
         {{0x1, 0x2}, {0x3}}, {{0x4}, {0x5, 0x6}},
         odil::VR::OB, odil::VR::OW,
         &odil::Element::is_binary,

--- a/tests/code/Value.cpp
+++ b/tests/code/Value.cpp
@@ -142,7 +142,7 @@ void test(
  
 BOOST_AUTO_TEST_CASE(Integers)
 {
-    test(
+    test<odil::Value::Integers>(
         {1234, 5678}, {9012, 3456},
         odil::Value::Type::Integers,
         &odil::Value::as_integers, &odil::Value::as_integers);
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(Integers)
 
 BOOST_AUTO_TEST_CASE(Reals)
 {
-    test(
+    test<odil::Value::Reals>(
         {12.34, 56.78}, {1., 2.},
         odil::Value::Type::Reals,
         &odil::Value::as_reals, &odil::Value::as_reals);
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(Reals)
 
 BOOST_AUTO_TEST_CASE(Strings)
 {
-    test(
+    test<odil::Value::Strings>(
         {"foo", "bar"}, {"plip", "plop"},
         odil::Value::Type::Strings,
         &odil::Value::as_strings, &odil::Value::as_strings);
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(DataSets)
     odil::DataSet data_set_2;
     data_set_2.add("EchoTime", {100});
 
-    test(
+    test<odil::Value::DataSets>(
         {data_set_1, data_set_2}, {data_set_2, data_set_1},
         odil::Value::Type::DataSets,
         &odil::Value::as_data_sets, &odil::Value::as_data_sets);
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(DataSets)
 
 BOOST_AUTO_TEST_CASE(Binary)
 {
-    test(
+    test<odil::Value::Binary>(
         {{0x1, 0x2}, {0x3}}, {{0x4}, {0x5, 0x6}},
         odil::Value::Type::Binary,
         &odil::Value::as_binary, &odil::Value::as_binary);


### PR DESCRIPTION
Visual Studio is not able to determine the type of TContainer. I think it is because as_xxx methods are ambiguous for the VS compiler.