### PR TITLE
Throw a SocketClosed exception when the socket is closed.

### DIFF
--- a/examples/genericscp.cpp
+++ b/examples/genericscp.cpp
@@ -124,6 +124,11 @@ int main()
         {
             dispatcher.dispatch();
         }
+        catch(odil::dul::SocketClosed const &)
+        {
+            std::cout << "Peer closed the socket" << std::endl;
+            done = true;
+        }
         catch(odil::AssociationReleased const &)
         {
             std::cout << "Peer released association" << std::endl;

--- a/src/odil/dul/Transport.cpp
+++ b/src/odil/dul/Transport.cpp
@@ -262,6 +262,11 @@ Transport
 
     if(source == Source::OPERATION)
     {
+        if(error == boost::asio::error::eof)
+        {
+            throw SocketClosed();
+        }
+
         if(error)
         {
             throw Exception("Operation error: "+error.message());

--- a/src/odil/dul/Transport.h
+++ b/src/odil/dul/Transport.h
@@ -15,6 +15,8 @@
 #include <boost/asio.hpp>
 #include <boost/date_time.hpp>
 
+#include "odil/Exception.h"
+
 namespace odil
 {
 
@@ -100,6 +102,20 @@ private:
     void _stop_deadline();
 
     void _run(Source & source, boost::system::error_code & error);
+};
+
+
+/** 
+ * @brief Exception reported when the socket is closed without releasing the association.
+ */
+class SocketClosed: public Exception
+{
+public:
+    SocketClosed()
+    : Exception("Socket closed")
+    {
+        // Nothing else.
+    }
 };
 
 }


### PR DESCRIPTION
There is currently no way to distinguish between the socket being closed and any exception occurring during message processing.
As a temporary measure, I propose to send a SocketClosed exception that must be processed by the user application (as is the case with AssociationReleased and AssociationAborted). In the future, it can be interesting to rewrite parts of the StateMachine and the Transport classes to ensure correct transitions (and true asynchronous operations).