### PR TITLE
Fix shutdown of the socket on windows

### DIFF
--- a/src/odil/dul/Transport.cpp
+++ b/src/odil/dul/Transport.cpp
@@ -157,7 +157,14 @@ Transport
     }
     if(this->is_open())
     {
-        this->_socket->shutdown(boost::asio::ip::tcp::socket::shutdown_both);
+        try
+        {
+            this->_socket->shutdown(boost::asio::ip::tcp::socket::shutdown_both);
+        }
+        catch(...)
+        {
+            // Only used to prevent uncatchable error on WIN32 platforms and in wrappers.
+        }
         this->_socket->close();
         this->_socket = nullptr;
     }


### PR DESCRIPTION
On windows, trying to destroy an association which has not been connected causes a crash. 